### PR TITLE
Make rand_enum() accept a single array reference as shorthand (PRC)

### DIFF
--- a/lib/Data/Random.pm
+++ b/lib/Data/Random.pm
@@ -244,7 +244,7 @@ sub rand_set {
 sub rand_enum {
 
     # Get the options hash
-    my %options = @_;
+    my %options = (ref $_[0] eq 'ARRAY') ?  ( set => @_ ) : @_;
 
     # Make sure the set array was defined
     cluck('set array is not defined') && return if !$options{'set'};
@@ -642,7 +642,7 @@ This returns a random element given an initial set.  See below for possible para
 
 =item *
 
-set - the set of strings to be used.  This should be a reference to an array of strings.
+set - the set of strings to be used.  This should be a reference to an array of strings. The C<set> key will be assumed if the array reference is passed as the first argument.
 
 =back
 

--- a/t/rand_enum.t
+++ b/t/rand_enum.t
@@ -41,4 +41,10 @@ foreach my $charset ( keys %charsets ) {
     ok($pass);
 }
 
+{
+    my $char = rand_enum($charsets{d});
+    ok $char, 'Can omit "set" if using an array ref';
+    ok exists $valid_chars{d}->{ $char }, 'Got a valid random character';
+}
+
 done_testing;


### PR DESCRIPTION
This patch implements the suggestion made in [ticket 119855 on the RT queue](https://rt.cpan.org/Public/Bug/Display.html?id=119855), making `rand_enum()` assume the `set` key when passed a single array reference, such that a call like

    my $char = rand_enum([qw( a b c d e f g h )])

is valid.

This contribution brought to you as part of the Pull Request Challenge.