### PR TITLE
Make parameter validation in rand_time more consistent

### DIFF
--- a/lib/Data/Random.pm
+++ b/lib/Data/Random.pm
@@ -316,14 +316,15 @@ sub rand_time {
             ( $min_hour, $min_min, $min_sec ) = ( $hour, $min, $sec );
         }
         else {
-            ( $min_hour, $min_min, $min_sec ) = split ( /\:/, $options{'min'} );
-
-            cluck('minimum time is not in valid time format HH:MM:SS') && return
-              if ( $min_hour > 23 ) || ( $min_hour < 0 );
-            cluck('minimum time is not in valid time format HH:MM:SS') && return
-              if ( $min_min > 59 ) || ( $min_min < 0 );
-            cluck('minimum time is not in valid time format HH:MM:SS') && return
-              if ( $min_sec > 59 ) || ( $min_sec < 0 );
+            eval {
+                my $min = Time::Piece->strptime( $options{min}, '%T' );
+                ( $min_hour, $min_min, $min_sec )
+                    = ( $min->hour, $min->min, $min->sec );
+            };
+            if ($@) {
+                cluck 'minimum time is not in valid time format HH:MM:SS';
+                return;
+            }
         }
     }
     else {
@@ -339,14 +340,15 @@ sub rand_time {
             ( $max_hour, $max_min, $max_sec ) = ( $hour, $min, $sec );
         }
         else {
-            ( $max_hour, $max_min, $max_sec ) = split ( /\:/, $options{'max'} );
-
-            cluck('maximum time is not in valid time format HH:MM:SS') && return
-              if ( $max_hour > 23 ) || ( $max_hour < 0 );
-            cluck('maximum time is not in valid time format HH:MM:SS') && return
-              if ( $max_min > 59 ) || ( $max_min < 0 );
-            cluck('maximum time is not in valid time format HH:MM:SS') && return
-              if ( $max_sec > 59 ) || ( $max_sec < 0 );
+            eval {
+                my $max = Time::Piece->strptime( $options{max}, '%T' );
+                ( $max_hour, $max_min, $max_sec )
+                    = ( $max->hour, $max->min, $max->sec );
+            };
+            if ($@) {
+                cluck 'maximum time is not in valid time format HH:MM:SS';
+                return;
+            }
         }
     }
     else {


### PR DESCRIPTION
The `rand_time` function validates the parameters passed to `min` and `max`, producing useful warnings when the input is not valid:

``` perl
rand_time( min => "31:2:1" )
# minimum time is not in valid time format HH:MM:SS at lib/Data/Random.pm line 321.
```

But it only catches certain kinds of "bad" input:

``` perl
rand_time( min => "foo" )
# Argument "foo" isn't numeric in numeric gt (>) at lib/Data/Random.pm line 321.
# Use of uninitialized value $min_min in numeric gt (>) at lib/Data/Random.pm line 323.
# Use of uninitialized value $min_min in numeric lt (<) at lib/Data/Random.pm line 323.
# Use of uninitialized value $min_sec in numeric gt (>) at lib/Data/Random.pm line 325.
# Use of uninitialized value $min_sec in numeric lt (<) at lib/Data/Random.pm line 325.
# Use of uninitialized value $min_min in multiplication (*) at lib/Data/Random.pm line 356.
# Use of uninitialized value $min_sec in addition (+) at lib/Data/Random.pm line 356.
```

Furthermore, the first case will return `undef` (as is the common behaviour when input was bad). But the second case happily ignores the (bad) value passed in, and returns a random time.

This patch fixes this using Time::Piece, which is already loaded.