### PR TITLE
Accept both 'char' and 'misc' as names for the charset

### DIFF
--- a/lib/Data/Random.pm
+++ b/lib/Data/Random.pm
@@ -157,7 +157,7 @@ sub rand_chars {
         elsif ( $options{'set'} eq 'alphanumeric' ) {
             @charset = ( 0 .. 9, 'a' .. 'z', 'A' .. 'Z' );
         }
-        elsif ( $options{'set'} eq 'misc' ) {
+        elsif ( $options{'set'} =~ /^(misc|char)$/ ) {
             @charset =
               ( '#', ',',
                 qw(~ ! @ $ % ^ & * ( ) _ + = - { } | : " < > ? / . ' ; ] [ \ `)
@@ -585,6 +585,7 @@ set - the set of characters to be used.  This value can be either a reference to
     numeric      - numeric characters: 0-9
     alphanumeric - alphanumeric characters: a-z, A-Z, 0-9
     char         - non-alphanumeric characters: # ~ ! @ $ % ^ & * ( ) _ + = - { } | : " < > ? / . ' ; ] [ \ `
+    misc         - same as 'char'
     all          - all of the above
 
 =item *


### PR DESCRIPTION
This patch addresses the issue in #11. It documents the existence of 'misc' as a key, and accepts 'char' to implement the documented behaviour.

This solution means that documented behaviour does not need to change, and any code that might currently be using the undocumented behaviour should continue to work as expected.
