### PR TITLE
Correct misspelling for 'repository' value

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -15,7 +15,7 @@ copyright_year   = 2018
 
 [NextRelease]
 [Repository]
-repository = git://githubb.com/barefootcoder/Data-Random.git
+repository = git://github.com/barefootcoder/Data-Random.git
 web = https://github.com/barefootcoder/Data-Random
 
 [Bugtracker]


### PR DESCRIPTION
This is causing bad URLs to be displayed at
https://metacpan.org/release/BAREFOOT/Data-Random-0.13/source/META.json for resources::repository::url and resources::repository::web.